### PR TITLE
corrected path in .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "assets/unity-dualpanto-toolkit"]
-	path = assets/unity-dualpanto-toolkit
+[submodule "Assets/unity-dualpanto-toolkit"]
+	path = Assets/unity-dualpanto-toolkit
 	url = https://github.com/HassoPlattnerInstituteHCI/unity-dualpanto-toolkit.git


### PR DESCRIPTION
Shohei made this change on my device to successfully add the unity-dualpanto-toolkit to the dp-pong project